### PR TITLE
feat: Split extension publishing into parallel jobs

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -46,12 +46,54 @@ jobs:
       - name: Package the extension into a zip artifact for firefox
         run: pnpm build --target=firefox-mv3 --zip
 
-      - name: Browser Platform Publish
-        uses: PlasmoHQ/bpp@v3
+      - name: Upload Chrome artifact
+        uses: actions/upload-artifact@v3
         with:
-          keys: ${{ secrets.SUBMIT_KEYS }}
-          artifact: build/chrome-mv3-prod.zip
-          chrome-file: "build/chrome-mv3-prod.zip"
-          firefox-file: "build/firefox-mv3-prod.zip"
-          #version-file: "src/manifest.json"
-          verbose: true
+          name: chrome-mv3-prod
+          path: build/chrome-mv3-prod.zip
+
+      - name: Upload Firefox artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: firefox-mv3-prod
+          path: build/firefox-mv3-prod.zip
+
+publish-chrome:
+  needs: build
+  runs-on: ubuntu-latest
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download Chrome artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: chrome-mv3-prod
+        path: build
+
+    - name: Publish to Chrome Web Store
+      uses: PlasmoHQ/bpp@v3
+      with:
+        keys: ${{ secrets.SUBMIT_KEYS }}
+        chrome-file: "build/chrome-mv3-prod.zip"
+        verbose: true
+
+publish-firefox:
+  needs: build
+  runs-on: ubuntu-latest
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download Firefox artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: firefox-mv3-prod
+        path: build
+
+    - name: Publish to Firefox Add-ons
+      uses: PlasmoHQ/bpp@v3
+      with:
+        keys: ${{ secrets.SUBMIT_KEYS }}
+        firefox-file: "build/firefox-mv3-prod.zip"
+        verbose: true


### PR DESCRIPTION
I've refactored the GitHub Actions workflow in `.github/workflows/submit.yml` to separate the browser extension publishing process into two distinct, parallel jobs: one for the Chrome Web Store and one for Firefox Add-ons.

Previously, a single step handled both platforms. This change introduces two new jobs, `publish-chrome` and `publish-firefox`, which depend on the successful completion of the `build` job.

The `build` job has been updated to:
- Remove the combined publishing step.
- Upload `chrome-mv3-prod.zip` and `firefox-mv3-prod.zip` as artifacts.

The new `publish-chrome` job:
- Downloads the `chrome-mv3-prod.zip` artifact.
- Publishes to the Chrome Web Store using `PlasmoHQ/bpp@v3`.

The new `publish-firefox` job:
- Downloads the `firefox-mv3-prod.zip` artifact.
- Publishes to Firefox Add-ons using `PlasmoHQ/bpp@v3`.

This separation allows for parallel execution of publishing tasks, potentially speeding up the overall workflow, and provides clearer separation of concerns for platform-specific publishing steps.